### PR TITLE
Zeek v4.1 compatibility

### DIFF
--- a/scripts/PROFINET/main.zeek
+++ b/scripts/PROFINET/main.zeek
@@ -32,7 +32,7 @@ export {
 
     ## Event that can be handled to access the profinet record as it is sent to the loggin framework.
     global log_profinet_dce_rpc: event(rec: Profinet_DCE_RPC);
-        
+
     ## header info
     type Profinet: record {
         ts              : time &log;                ## Timestamp for when the event happened.
@@ -59,7 +59,7 @@ export {
         };
 
     ## Event that can be handled to access the profinet record as it is sent to the loggin framework.
-    global log_profinet_debug: event(rec: Profinet_Debug);    
+    global log_profinet_debug: event(rec: Profinet_Debug);
     }
 
 redef record connection += {
@@ -84,7 +84,7 @@ event zeek_init() &priority=5 {
     Log::create_stream(Profinet::Log_Profinet,
                         [$columns=Profinet,
                         $ev=log_profinet,
-                        $path="profinet"]);    
+                        $path="profinet"]);
     Log::create_stream(Profinet::Log_Profinet_Debug,
                         [$columns=Profinet_Debug,
                         $ev=log_profinet_debug,
@@ -116,6 +116,7 @@ event profinet_dce_rpc(c:connection, is_orig: bool,
                         ) {
     if(!c?$profinet_dce_rpc) {
         c$profinet_dce_rpc = [$ts=network_time(), $uid=c$uid, $id=c$id];
+        add c$service["profinet_dce_rpc"];
         }
 
     c$profinet_dce_rpc$ts = network_time();
@@ -138,7 +139,7 @@ event profinet_dce_rpc(c:connection, is_orig: bool,
                                             bytestring_to_hexstr(activity_uuid_part5));
     c$profinet_dce_rpc$server_boot_time = server_boot_time;
     c$profinet_dce_rpc$operation = operations[operation_number];
-    
+
     Log::write(Log_Profinet_DCE_RPC, c$profinet_dce_rpc);
     }
 
@@ -153,6 +154,7 @@ event profinet(c:connection, is_orig: bool,
                 ) {
     if(!c?$profinet) {
         c$profinet = [$ts=network_time(), $uid=c$uid, $id=c$id];
+        add c$service["profinet"];
         }
 
     c$profinet$ts = network_time();
@@ -169,6 +171,7 @@ event profinet(c:connection, is_orig: bool,
 event profinet_debug(c:connection, is_orig: bool, raw_data: string) {
     if(!c?$profinet_debug) {
         c$profinet_debug = [$ts=network_time(), $uid=c$uid, $id=c$id];
+        add c$service["profinet"];
         }
 
     c$profinet_debug$ts = network_time();

--- a/src/PROFINET.cc
+++ b/src/PROFINET.cc
@@ -3,7 +3,7 @@
 
 using namespace analyzer::profinet;
 
-PROFINET_Analyzer::PROFINET_Analyzer(Connection* c): analyzer::Analyzer("PROFINET", c) {
+PROFINET_Analyzer::PROFINET_Analyzer(zeek::Connection* c): zeek::analyzer::Analyzer("PROFINET", c) {
     interp = new binpac::PROFINET::PROFINET_Conn(this);
     }
 
@@ -15,14 +15,14 @@ void PROFINET_Analyzer::Done() {
     Analyzer::Done();
     }
 
-void PROFINET_Analyzer::DeliverPacket(int len, const u_char* data, bool orig, uint64_t seq, const IP_Hdr* ip, int caplen) {
+void PROFINET_Analyzer::DeliverPacket(int len, const u_char* data, bool orig, uint64_t seq, const zeek::IP_Hdr* ip, int caplen) {
     Analyzer::DeliverPacket(len, data, orig, seq, ip, caplen);
 
     try {
         interp->NewData(orig, data, data + len);
         }
     catch(const binpac::Exception& e) {
-        ProtocolViolation(fmt("Binpac exception: %s", e.c_msg()));
+        ProtocolViolation(zeek::util::fmt("Binpac exception: %s", e.c_msg()));
         }
     }
 

--- a/src/PROFINET.h
+++ b/src/PROFINET.h
@@ -2,7 +2,11 @@
 #define ANALYZER_PROTOCOL_PROFINET_H
 
 #include "events.bif.h"
+#if ZEEK_VERSION_NUMBER >= 40100
 #include <zeek/packet_analysis/protocol/udp/UDPSessionAdapter.h>
+#else
+#include <zeek/analyzer/protocol/udp/UDP.h>
+#endif
 #include "profinet_pac.h"
 
 namespace analyzer {

--- a/src/PROFINET.h
+++ b/src/PROFINET.h
@@ -2,27 +2,27 @@
 #define ANALYZER_PROTOCOL_PROFINET_H
 
 #include "events.bif.h"
-#include "analyzer/protocol/udp/UDP.h"
+#include <zeek/packet_analysis/protocol/udp/UDPSessionAdapter.h>
 #include "profinet_pac.h"
 
-namespace analyzer { 
+namespace analyzer {
     namespace profinet {
-        class PROFINET_Analyzer : public analyzer::Analyzer {
+        class PROFINET_Analyzer : public zeek::analyzer::Analyzer {
             public:
-                PROFINET_Analyzer(Connection* conn);
+                PROFINET_Analyzer(zeek::Connection* conn);
                 virtual ~PROFINET_Analyzer();
 
                 virtual void Done();
-                virtual void DeliverPacket(int len, const u_char* data, bool orig, uint64_t seq, const IP_Hdr* ip, int caplen);
+                virtual void DeliverPacket(int len, const u_char* data, bool orig, uint64_t seq, const zeek::IP_Hdr* ip, int caplen);
 
-                static analyzer::Analyzer* Instantiate(Connection* conn) { 
+                static zeek::analyzer::Analyzer* Instantiate(zeek::Connection* conn) {
                     return new PROFINET_Analyzer(conn);
                     }
 
             protected:
                 binpac::PROFINET::PROFINET_Conn* interp;
             };
-        } 
+        }
     }
 
 #endif

--- a/src/Plugin.cc
+++ b/src/Plugin.cc
@@ -1,7 +1,7 @@
 #include "Plugin.h"
-#include "analyzer/Component.h"
+#include "zeek/analyzer/Component.h"
 
-namespace plugin { 
+namespace plugin {
     namespace Zeek_PROFINET {
         Plugin plugin;
         }
@@ -9,10 +9,10 @@ namespace plugin {
 
 using namespace plugin::Zeek_PROFINET;
 
-plugin::Configuration Plugin::Configure() {
-    AddComponent(new ::analyzer::Component("PROFINET", ::analyzer::profinet::PROFINET_Analyzer::Instantiate));
-    
-    plugin::Configuration config;
+zeek::plugin::Configuration Plugin::Configure() {
+    AddComponent(new zeek::analyzer::Component("PROFINET", analyzer::profinet::PROFINET_Analyzer::Instantiate));
+
+    zeek::plugin::Configuration config;
     config.name = "Zeek::PROFINET";
     config.description = "PROFINET protocol analyzer";
     return config;

--- a/src/Plugin.h
+++ b/src/Plugin.h
@@ -1,15 +1,15 @@
 #ifndef ZEEK_PLUGIN_ZEEK_PROFINET
 #define ZEEK_PLUGIN_ZEEK_PROFINET
 
-#include <plugin/Plugin.h>
+#include <zeek/plugin/Plugin.h>
 #include "PROFINET.h"
 
 namespace plugin {
     namespace Zeek_PROFINET {
-        class Plugin : public ::plugin::Plugin {
+        class Plugin : public zeek::plugin::Plugin {
             protected:
                 // Overridden from plugin::Plugin.
-                virtual plugin::Configuration Configure();
+                virtual zeek::plugin::Configuration Configure();
             };
 
         extern Plugin plugin;

--- a/src/events.bif
+++ b/src/events.bif
@@ -7,7 +7,7 @@
 ## c: The connection the Profinet communication is part of.
 ## is_orig: True if this reflects originator-side activity.
 ## self explanatory parameters
-## 
+##
 event profinet_dce_rpc%(c: connection,
                         is_orig: bool,
                         version: count,
@@ -36,10 +36,10 @@ event profinet_dce_rpc%(c: connection,
 ###########################################
 ## c: The connection the Profinet communication is part of.
 ## is_orig: True if this reflects originator-side activity.
-## operation_type: Header code (see const.bro).
+## operation_type: Header code (see consts.zeek).
 ## command1: command1 type.
-## command2: look at consts.bro for more info
-## 
+## command2: look at consts.zeek for more info
+##
 event profinet%(c: connection,
                 is_orig: bool,
                 operation_type: count,
@@ -56,7 +56,7 @@ event profinet%(c: connection,
 ## c: The connection the Profinet communication is part of.
 ## is_orig: True if this reflects originator-side activity.
 ## raw_data: dump everything here
-## 
+##
 event profinet_debug%(c: connection,
                         is_orig: bool,
                         raw_data: string

--- a/src/profinet-analyzer.pac
+++ b/src/profinet-analyzer.pac
@@ -1,7 +1,7 @@
 ## Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 ## SPDX-License-Identifier: BSD-3-Clause
 
-connection PROFINET_Conn(bro_analyzer: BroAnalyzer) {
+connection PROFINET_Conn(zeek_analyzer: ZeekAnalyzer) {
     upflow   = PROFINET_Flow(true);
     downflow = PROFINET_Flow(false);
     };
@@ -17,30 +17,30 @@ flow PROFINET_Flow(is_orig: bool) {
 
     function profinet_dce_rpc(header: Profinet_DCE_RPC): bool %{
         if(::profinet_dce_rpc) {
-            connection()->bro_analyzer()->ProtocolConfirmation();
-            BifEvent::generate_profinet_dce_rpc(connection()->bro_analyzer(),
-                                connection()->bro_analyzer()->Conn(),
-                                is_orig(),
-                                ${header.version},
-                                ${header.packet_type},
-                                (${header.object_uuid.part1}),
-                                (${header.object_uuid.part2}),
-                                (${header.object_uuid.part3}),
-                                (${header.object_uuid.part4}),
-                                bytestring_to_val(${header.object_uuid.part5}),
-                                (${header.interface_uuid.part1}),
-                                (${header.interface_uuid.part2}),
-                                (${header.interface_uuid.part3}),
-                                (${header.interface_uuid.part4}),
-                                bytestring_to_val(${header.interface_uuid.part5}),
-                                (${header.activity_uuid.part1}),
-                                (${header.activity_uuid.part2}),
-                                (${header.activity_uuid.part3}),
-                                (${header.activity_uuid.part4}),
-                                bytestring_to_val(${header.activity_uuid.part5}),
-                                ${header.server_boot_time},
-                                ${header.operation_number}
-                                );
+            connection()->zeek_analyzer()->ProtocolConfirmation();
+            zeek::BifEvent::enqueue_profinet_dce_rpc(connection()->zeek_analyzer(),
+                                                     connection()->zeek_analyzer()->Conn(),
+                                                     is_orig(),
+                                                     ${header.version},
+                                                     ${header.packet_type},
+                                                     (${header.object_uuid.part1}),
+                                                     (${header.object_uuid.part2}),
+                                                     (${header.object_uuid.part3}),
+                                                     (${header.object_uuid.part4}),
+                                                     to_stringval(${header.object_uuid.part5}),
+                                                     (${header.interface_uuid.part1}),
+                                                     (${header.interface_uuid.part2}),
+                                                     (${header.interface_uuid.part3}),
+                                                     (${header.interface_uuid.part4}),
+                                                     to_stringval(${header.interface_uuid.part5}),
+                                                     (${header.activity_uuid.part1}),
+                                                     (${header.activity_uuid.part2}),
+                                                     (${header.activity_uuid.part3}),
+                                                     (${header.activity_uuid.part4}),
+                                                     to_stringval(${header.activity_uuid.part5}),
+                                                     ${header.server_boot_time},
+                                                     ${header.operation_number}
+                                                     );
             }
 
         return true;
@@ -48,17 +48,17 @@ flow PROFINET_Flow(is_orig: bool) {
 
     function profinet(header: PROFINET): bool %{
         if(::profinet) {
-            connection()->bro_analyzer()->ProtocolConfirmation();
-            BifEvent::generate_profinet(connection()->bro_analyzer(),
-                            connection()->bro_analyzer()->Conn(),
-                            is_orig(),
-                            ${header.block_header.operation_type},
-                            ${header.block_header.version_high},
-                            ${header.block_header.version_low},
-                            ${header.slot_number},
-                            ${header.subslot_number},
-                            ${header.index}
-                            );
+            connection()->zeek_analyzer()->ProtocolConfirmation();
+            zeek::BifEvent::enqueue_profinet(connection()->zeek_analyzer(),
+                                             connection()->zeek_analyzer()->Conn(),
+                                             is_orig(),
+                                             ${header.block_header.operation_type},
+                                             ${header.block_header.version_high},
+                                             ${header.block_header.version_low},
+                                             ${header.slot_number},
+                                             ${header.subslot_number},
+                                             ${header.index}
+                                             );
         }
 
         return true;
@@ -66,23 +66,23 @@ flow PROFINET_Flow(is_orig: bool) {
 
     function profinet_debug(raw_data: bytestring): bool %{
         if(::profinet_debug) {
-            connection()->bro_analyzer()->ProtocolViolation(fmt("unknown ProfiNet"));
-            BifEvent::generate_profinet_debug(connection()->bro_analyzer(),
-                            connection()->bro_analyzer()->Conn(),
-                            is_orig(),
-                            bytestring_to_val(raw_data)
-                            );
+            connection()->zeek_analyzer()->ProtocolViolation(zeek::util::fmt("unknown ProfiNet"));
+            zeek::BifEvent::enqueue_profinet_debug(connection()->zeek_analyzer(),
+                                                   connection()->zeek_analyzer()->Conn(),
+                                                   is_orig(),
+                                                   to_stringval(raw_data)
+                                                   );
         }
 
         return true;
-        %}                
-        
+        %}
+
     };
 
 refine typeattr Profinet_DCE_RPC += &let {
      proc: bool = $context.flow.profinet_dce_rpc(this);
      };
-    
+
 refine typeattr PROFINET += &let {
     proc: bool = $context.flow.profinet(this);
     };

--- a/src/profinet.pac
+++ b/src/profinet.pac
@@ -1,5 +1,5 @@
-%include binpac.pac
-%include bro.pac
+%include zeek/binpac.pac
+%include zeek/zeek.pac
 
 %extern{
     #include "events.bif.h"

--- a/zkg.meta
+++ b/zkg.meta
@@ -5,5 +5,5 @@ tags = zeek plugin, protocol analyzer, log writer, ics, profinet
 description = Plugin that enables parsing of the Profinet protocol
 depends =
   zkg >=2.0
-  zeek >=3.0.0
+  zeek >=4.0.0
 


### PR DESCRIPTION
 Plugin updates for Zeek v4.1.x compatibility

- Rename deprecated (now removed) "bro" references to "zeek"
- Fixed various issues in .cc and .pac files for namespaces, renamed
  types, include file locations, etc.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
