### PR TITLE
replace removed ProtocolConfirmation and ProtocolViolation calls

### DIFF
--- a/src/PROFINET.cc
+++ b/src/PROFINET.cc
@@ -22,7 +22,7 @@ void PROFINET_Analyzer::DeliverPacket(int len, const u_char* data, bool orig, ui
         interp->NewData(orig, data, data + len);
         }
     catch(const binpac::Exception& e) {
-        ProtocolViolation(zeek::util::fmt("Binpac exception: %s", e.c_msg()));
+        AnalyzerViolation(zeek::util::fmt("Binpac exception: %s", e.c_msg()));
         }
     }
 

--- a/src/profinet-analyzer.pac
+++ b/src/profinet-analyzer.pac
@@ -17,7 +17,7 @@ flow PROFINET_Flow(is_orig: bool) {
 
     function profinet_dce_rpc(header: Profinet_DCE_RPC): bool %{
         if(::profinet_dce_rpc) {
-            connection()->zeek_analyzer()->ProtocolConfirmation();
+            connection()->zeek_analyzer()->AnalyzerConfirmation();
             zeek::BifEvent::enqueue_profinet_dce_rpc(connection()->zeek_analyzer(),
                                                      connection()->zeek_analyzer()->Conn(),
                                                      is_orig(),
@@ -48,7 +48,7 @@ flow PROFINET_Flow(is_orig: bool) {
 
     function profinet(header: PROFINET): bool %{
         if(::profinet) {
-            connection()->zeek_analyzer()->ProtocolConfirmation();
+            connection()->zeek_analyzer()->AnalyzerConfirmation();
             zeek::BifEvent::enqueue_profinet(connection()->zeek_analyzer(),
                                              connection()->zeek_analyzer()->Conn(),
                                              is_orig(),
@@ -66,7 +66,7 @@ flow PROFINET_Flow(is_orig: bool) {
 
     function profinet_debug(raw_data: bytestring): bool %{
         if(::profinet_debug) {
-            connection()->zeek_analyzer()->ProtocolViolation(zeek::util::fmt("unknown ProfiNet"));
+            connection()->zeek_analyzer()->AnalyzerViolation(zeek::util::fmt("unknown ProfiNet"));
             zeek::BifEvent::enqueue_profinet_debug(connection()->zeek_analyzer(),
                                                    connection()->zeek_analyzer()->Conn(),
                                                    is_orig(),


### PR DESCRIPTION
Replace ProtocolConfirmation and ProtocolViolation with AnalyzerConfirmation and AnalyzerViolation so the plugin works in modern Zeek installations

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.